### PR TITLE
enable more tests (like vp9) in FF

### DIFF
--- a/apprtc.js
+++ b/apprtc.js
@@ -6,6 +6,7 @@
  */
 
 var test = require('tape');
+var fs = require('fs');
 var webdriver = require('selenium-webdriver');
 var buildDriver = require('./webdriver').buildDriver;
 
@@ -158,7 +159,6 @@ test('Firefox-Firefox, H264', function(t) {
   });
 });
 
-/*
 test('Chrome-Chrome, H264', function(t) {
   interop(t, 'chrome', 'chrome', '?vsc=H264&vrc=H264')
   .then(function(info) {
@@ -174,9 +174,7 @@ test('Chrome-Firefox, H264', function(t) {
     t.end();
   });
 });
-*/
 
-/*
 test('Firefox-Chrome, H264', function(t) {
   interop(t, 'firefox', 'chrome', '?vsc=H264&vrc=H264')
   .then(function(info) {
@@ -198,13 +196,10 @@ test('Chrome-Chrome, VP9', function(t) {
     t.end();
   });
 });
-*/
 
-/*
 test('Firefox-Firefox, VP9', function(t) {
   interop(t, 'firefox', 'firefox', '?vsc=VP9&vrc=VP9')
   .then(function(info) {
     t.end();
   });
 });
-*/

--- a/apprtc.js
+++ b/apprtc.js
@@ -13,7 +13,7 @@ var buildDriver = require('./webdriver').buildDriver;
 // Helper function for basic interop test.
 // see https://apprtc.appspot.com/params.html for queryString options (outdated...)
 function interop(t, browserA, browserB, queryString) {
-  var driverA = buildDriver(browserA);
+  var driverA = buildDriver(browserA, {h264: true});
   var driverB;
 
   var baseURL = 'https://apprtc.appspot.com/';
@@ -38,7 +38,7 @@ function interop(t, browserA, browserB, queryString) {
   })
   .then(function(url) {
     //
-    driverB = buildDriver(browserB);
+    driverB = buildDriver(browserB, {h264: true});
     return driverB.get(url);
   })
   .then(function() {
@@ -199,6 +199,20 @@ test('Chrome-Chrome, VP9', function(t) {
 
 test('Firefox-Firefox, VP9', function(t) {
   interop(t, 'firefox', 'firefox', '?vsc=VP9&vrc=VP9')
+  .then(function(info) {
+    t.end();
+  });
+});
+
+test('Chrome-Firefox, VP9', function(t) {
+  interop(t, 'chrome', 'firefox', '?vsc=VP9&vrc=VP9')
+  .then(function(info) {
+    t.end();
+  });
+});
+
+test('Firefox-Chrome, VP9', function(t) {
+  interop(t, 'firefox', 'chrome', '?vsc=VP9&vrc=VP9')
   .then(function(info) {
     t.end();
   });


### PR DESCRIPTION
enable more tests for Firefox.

Currently one failure:

```
# Chrome-Firefox, H264
ok 37 page loaded
ok 38 joined room
ok 39 second browser joined
ok 40 ice connection state is connected or completed
ok 41 video frames received
not ok 42 H264 is used
  ---
    operator: ok
    expected: true
    actual:   false
    at: ManagedPromise.invokeCallback_ (/home/fippo/webrtc/testbed/node_modules/selenium-webdriver/lib/promise.js:1303:14)
  ...
```
