### PR TITLE
video: add Edge VP8 tests

### DIFF
--- a/video.js
+++ b/video.js
@@ -239,6 +239,14 @@ test('Firefox-Edge', {skip: os.platform() !== 'win32'}, function (t) {
   video(t, 'firefox', 'MicrosoftEdge', 'H264');
 });
 
+// VP8 is available since Edge 15014
+test('Edge-Chrome VP8', {skip: os.platform() !== 'win32'}, function (t) {
+  video(t, 'MicrosoftEdge', 'chrome', 'VP8');
+});
+
+test('Edge-Firefox VP8', {skip: os.platform() !== 'win32'}, function (t) {
+  video(t, 'MicrosoftEdge', 'firefox', 'VP8');
+});
 /*
 test('Edge-Edge', {skip: os.platform() !== 'win32'}, function (t) {
   video(t, 'MicrosoftEdge', 'MicrosoftEdge', 'H264');


### PR DESCRIPTION
adds Edge -> (Chrome/Firefox) tests. The other direction does not work yet
due to a bug in adapter.js (which prefers H264 over VP8 in the answer)