### PR TITLE
webdriver: use local adapter version

### DIFF
--- a/package.json
+++ b/package.json
@@ -8,7 +8,8 @@
     "geckodriver": "^1.1.3",
     "sdp": "^1.0.0",
     "selenium-webdriver": "^3.0.0",
-    "tape": "^4.5.1"
+    "tape": "^4.5.1",
+    "webrtc-adapter": "^3.1.6"
   },
   "scripts": {
     "start": "node video.js"

--- a/webdriver.js
+++ b/webdriver.js
@@ -121,7 +121,10 @@ function buildDriver(browser, options) {
 
 // static page that includes adapter.js 
 function getTestpage(driver) {
-    return driver.get('https://fippo.github.io/adapter/testpage.html')
+    return driver.get('https://fippo.github.io/adapter/empty.html')
+    .then(() => {
+        driver.executeScript(fs.readFileSync('node_modules/webrtc-adapter/out/adapter.js').toString());
+    });
 }
 
 module.exports = {


### PR DESCRIPTION
uses a local adapter.js version for the test page.
this makes it easier to change adapter.js