### PR TITLE
webdriver: allow specifying selenium hub url

### DIFF
--- a/webdriver.js
+++ b/webdriver.js
@@ -103,8 +103,10 @@ function buildDriver(browser, options) {
       .setChromeOptions(chromeOptions)
       .setEdgeOptions(edgeOptions)
       .forBrowser(browser);
-  if (options.server) {
+  if (options.server === 'true') {
     driver = driver.usingServer('http://localhost:4444/wd/hub/');
+  } else if (options.server) {
+    driver = driver.usingServer(options.server);
   }
 
   if (browser === 'firefox') {


### PR DESCRIPTION
allows specifying the selenium hub url. For cases where the
selenium is running somewhere else.