### PR TITLE
Use vendor-prefix attributes for browser options

### DIFF
--- a/webdriver.js
+++ b/webdriver.js
@@ -162,6 +162,12 @@ function buildDriver(browser, options) {
       .setSafariOptions(safariOptions)
       .setLoggingPrefs(loggingPreferences)
       .forBrowser(browser);
+  if (browser === 'chrome') {
+    driver.getCapabilities().set('goog:chromeOptions', chromeOptions);
+  }
+  if (browser === 'firefox') {
+    driver.getCapabilities().set('moz:firefoxOptions', firefoxOptions);
+  }
   if (options.server === true) {
     driver = driver.usingServer('http://localhost:4444/wd/hub/');
   } else if (options.server) {


### PR DESCRIPTION
Newer versions of selenium seem to require this -- not sure why
setChromeOptions / setFirefoxOptions are not using these names...